### PR TITLE
feat: Add an option to continue the dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,17 @@ exports['mojito_dialogue']:NewDialogueCallback(`a_m_y_skater_02`, vec4(-727.74, 
         {text = "Yes", value="yes"},
         {text = "No", value="no"}
     }
-}, function(selection)
+}, function(selection, next, exit)
     if selection == "yes" then
-     QBCore.Functions.Notify("You picked yes", "success")
+        next({
+            title = "Next title",
+            items = {
+                {text = "Yes", value="yes"},
+                {text = "No", value="no"}
+            }
+        })
     else
-     QBCore.Functions.Notify("You picked no", "error")
+        exit()
     end
 end)
 ```
@@ -32,8 +38,18 @@ exports['mojito_dialogue']:NewDialogueEvent(`a_m_y_skater_02`, vec4(-727.74, -14
     }
 }, "myscript:client:onInteract")
 
-AddEventHandler("myscript:client:onInteract", function(selection)
-    print(selection) -- "yes" or "no" 
+AddEventHandler("myscript:client:onInteract", function(selection, next, exit)
+    if selection == "yes" then
+        next({
+            title = "Next title",
+            items = {
+                {text = "Yes", value="yes"},
+                {text = "No", value="no"}
+            }
+        })
+    else
+        exit()
+    end
 end)
 ```
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -183,6 +183,14 @@ local function ExitDialogue()
     interactingWith = nil
 end
 
+local function NextDialogue(data)
+    SendNUIMessage({
+        type = "newDialogue",
+        title = data.title,
+        items = data.items
+    })
+end
+
 RegisterCommand("exitdialogue", ExitDialogue)
 RegisterKeyMapping("exitdialogue", "Exit current dialogue interaction", "keyboard", "BACK") -- Default key to exit as backspace
 
@@ -192,11 +200,10 @@ RegisterNUICallback('select', function(data, cb)
     local Ped = FindPed()
 
     if Ped.cb ~= nil then
-        Ped.cb(selection)
+        Ped.cb(selection, NextDialogue, ExitDialogue)
     elseif Ped.event ~= nil then
-        TriggerEvent(Ped.event, selection)
+        TriggerEvent(Ped.event, selection, NextDialogue, ExitDialogue)
     end
 
-    ExitDialogue()
     cb({})
 end)


### PR DESCRIPTION
## What?
I've added support for the conversation to be able to continue with the same ped.

## Why?
This gives you the opportunity to create more in-depth dialogues.

## How?
The callback now accepts two additional parameters that can be used as functions to skip to the next dialog and close the dialog.
